### PR TITLE
fix: use ansible_facts[] to silence INJECT_FACTS_AS_VARS deprecation

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -153,5 +153,5 @@ ansible_ca_cert:
   path: ~/ansible_ca/certificate
   valid: +356d
   subject_alt_name:
-    - "DNS:{{ ansible_fqdn }}"
-    - "DNS:{{ ansible_default_ipv4.address }}"
+    - "DNS:{{ ansible_facts['fqdn'] }}"
+    - "DNS:{{ ansible_facts['default_ipv4'].address }}"

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Install vault CA to Debian os system
   ansible.builtin.shell: /usr/sbin/update-ca-certificates
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install vault CA to RedHat os system
   ansible.builtin.shell: /bin/update-ca-trust
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"

--- a/tasks/generate-vault-cert.yaml
+++ b/tasks/generate-vault-cert.yaml
@@ -19,7 +19,7 @@
     body:
       common_name: "{{ vault_url | urlsplit('hostname') }}"
       ttl: "{{ vault_gen_vault_cert_ttl }}"
-      ip_sans: "{{ ansible_default_ipv4.address }}"
+      ip_sans: "{{ ansible_facts['default_ipv4'].address }}"
     headers:
       X-Vault-Request: true
       X-Vault-Token: "{{ vault_token }}"

--- a/tasks/install-ca-auth.yaml
+++ b/tasks/install-ca-auth.yaml
@@ -31,7 +31,7 @@
 - name: Copy certificate authority to trusted ca path of the os
   ansible.builtin.copy:
     content: "{{ vault_install_ca_cert_download.content }}"
-    dest: '{{ vault_install_ca_cert_ca_path[ansible_os_family][ansible_distribution_major_version|int] }}'
+    dest: "{{ vault_install_ca_cert_ca_path[ansible_facts['os_family']][ansible_facts['distribution_major_version']|int] }}"
     owner: root
     group: root
     mode: 0644

--- a/templates/vault_config_raft.hcl.j2
+++ b/templates/vault_config_raft.hcl.j2
@@ -1,7 +1,7 @@
 ui = true
 log_level = "Debug"
-cluster_addr = "https://{{ hostvars[groups['member'][0]].ansible_fqdn }}:8200"
-api_addr = "https://{{ hostvars[groups['member'][0]].ansible_fqdn }}:8201"
+cluster_addr = "https://{{ hostvars[groups['member'][0]]['ansible_facts']['fqdn'] }}:8200"
+api_addr = "https://{{ hostvars[groups['member'][0]]['ansible_facts']['fqdn'] }}:8201"
 listener "tcp" {
   tls_disable = 0
   address = "[::]:8200"
@@ -12,10 +12,10 @@ storage "raft" {
   path = "/vault/raft"
 {% for host in groups['member'] %}
   retry_join {
-    leader_api_addr = "https://{{ hostvars[host]['ansible_fqdn'] }}:8200"
+    leader_api_addr = "https://{{ hostvars[host]['ansible_facts']['fqdn'] }}:8200"
     leader_ca_cert_file = "/etc/certificate/{{ ansible_ca.crt }}"
-    leader_client_cert_file = "/etc/certificate/{{ hostvars[host]['ansible_fqdn'] }}.crt"
-    leader_client_key_file = "/etc/certificate/{{ hostvars[host]['ansible_fqdn'] }}.key"
+    leader_client_cert_file = "/etc/certificate/{{ hostvars[host]['ansible_facts']['fqdn'] }}.crt"
+    leader_client_key_file = "/etc/certificate/{{ hostvars[host]['ansible_facts']['fqdn'] }}.key"
    }
 {% endfor %}
 

--- a/vars/vault-server.yaml
+++ b/vars/vault-server.yaml
@@ -31,8 +31,8 @@ ports:
     container: 8201
 generate_certs: "{% if upgrade_vault == true %}false{% elif upgrade_vault == false %}true{% endif %}"
 certificate_option: selfsigned
-cert_ssl_subject: "{{ ansible_fqdn }}"
-cert_ssl_ip: "{{ ansible_default_ipv4.address }}"
+cert_ssl_subject: "{{ ansible_facts['fqdn'] }}"
+cert_ssl_ip: "{{ ansible_facts['default_ipv4'].address }}"
 cert_mount_target: "{{ mounts.certs.host }}"
 cert_key_name: vault.key
 cert_crt_name: vault.crt


### PR DESCRIPTION
## Summary
- Replace top-level `ansible_os_family`, `ansible_distribution_major_version`, `ansible_fqdn`, `ansible_default_ipv4` with `ansible_facts[...]` form across defaults, vars, handlers, tasks, and `templates/vault_config_raft.hcl.j2` (including `hostvars[host]['ansible_facts']['fqdn']` lookups).
- Silences `INJECT_FACTS_AS_VARS` deprecation warnings on ansible-core 2.20+ and prepares for removal in 2.24.

Refs: stuttgart-things/ansible#829

## Test plan
- [ ] Run vault install role end-to-end; confirm CA install handler fires on Debian+RedHat targets.
- [ ] Validate generated `vault_config_raft.hcl` cluster/api/retry_join addrs still resolve correctly from hostvars.
- [ ] Confirm no deprecation warnings remain.